### PR TITLE
[FR] Changed `scanForPrinters` to store discovered devices, and `connect` to specific device

### DIFF
--- a/core/src/androidMain/kotlin/com/dilivva/blueline/core/connection/bluetooth/AndroidBluetoothConnection.kt
+++ b/core/src/androidMain/kotlin/com/dilivva/blueline/core/connection/bluetooth/AndroidBluetoothConnection.kt
@@ -111,7 +111,14 @@ internal class AndroidBluetoothConnection: BlueLine {
 
         override fun onConnectionStateChange(gatt: BluetoothGatt?, status: Int, newState: Int) {
             if (newState == BluetoothProfile.STATE_CONNECTED) {
-                stateFlow.update { state -> state.copy(isConnected = true, isConnecting = false, bluetoothConnectionError = null) }
+                stateFlow.update {
+                    it.copy(
+                        isConnected = true,
+                        isConnecting = false,
+                        bluetoothConnectionError = null,
+                        connectedDevice = stateFlow.value.discoveredDevices[gatt!!.device.address]
+                    )
+                }
                 gatt?.discoverServices()
             }else{
                 stateFlow.update {

--- a/core/src/androidMain/kotlin/com/dilivva/blueline/core/connection/bluetooth/AndroidBluetoothConnection.kt
+++ b/core/src/androidMain/kotlin/com/dilivva/blueline/core/connection/bluetooth/AndroidBluetoothConnection.kt
@@ -57,7 +57,6 @@ internal class AndroidBluetoothConnection: BlueLine {
     private val printerUUID = ParcelUuid.fromString("000018F0-0000-1000-8000-00805F9B34FB")
     private val characterUuid = UUID.fromString("00002AF1-0000-1000-8000-00805F9B34FB")
 
-    private var bluetoothDevice: BluetoothDevice? = null
     private var bluetoothLeScanner = bluetoothAdapter?.bluetoothLeScanner
     private var bluetoothGatt: BluetoothGatt? = null
     private var characteristic: BluetoothGattCharacteristic? = null
@@ -83,14 +82,29 @@ internal class AndroidBluetoothConnection: BlueLine {
         }
     )
 
+    private val discoveredDevicesList = mutableMapOf<String, SimpleBluetoothDevice>()
+
     private val scanCallback = object: ScanCallback(){
         override fun onScanResult(callbackType: Int, result: ScanResult?) {
-            val device = result?.device
-            if (device != null){
-                bluetoothLeScanner?.stopScan(this)
-                bluetoothDevice = device
-                stateFlow.update { state -> state.copy(deviceName = device.name.orEmpty(), discoveredPrinter = true, isScanning = false) }
+            result?.device?.let { device ->
+                discoveredDevicesList[device.address] = SimpleBluetoothDevice(
+                    name = device.name,
+                    address = device.address,
+                    bluetoothDevice = device,
+                )
+                stateFlow.update { state ->
+                    state.copy(
+                        discoveredDevices = discoveredDevicesList,
+                        discoveredPrinter = true,
+                        isScanning = true
+                    )
+                }
             }
+        }
+
+        override fun onScanFailed(errorCode: Int) {
+            super.onScanFailed(errorCode)
+            stateFlow.update { it.copy(isScanning = false, bluetoothConnectionError = ConnectionError.BLUETOOTH_SCAN_FAILED) }
         }
     }
     private val gattCallback = object: BluetoothGattCallback(){
@@ -177,34 +191,62 @@ internal class AndroidBluetoothConnection: BlueLine {
         if (!stateFlow.value.isBluetoothReady){
             return
         }
+        discoveredDevicesList.clear()
+        stateFlow.update { it.copy(discoveredDevices = emptyMap<String, SimpleBluetoothDevice>().toMutableMap(), isScanning = true, bluetoothConnectionError = null) }
+
         val pairedDevices: Set<BluetoothDevice>? = bluetoothAdapter?.bondedDevices
-        val pairedPrinter = pairedDevices?.find { it.isPrinter() }
-        if (pairedPrinter != null){
-            bluetoothDevice = pairedPrinter
-            stateFlow.update { state -> state.copy(deviceName = pairedPrinter.name.orEmpty(), discoveredPrinter = true) }
-            return
+        pairedDevices?.forEach { device ->
+            if (device.isPrinter()) {
+                discoveredDevicesList[device.address] = SimpleBluetoothDevice(
+                    name = device.name,
+                    address = device.address,
+                    bluetoothDevice = device,
+                )
+            }
         }
+        stateFlow.update { it.copy(discoveredDevices = discoveredDevicesList) }
         scanLeDevice()
 
     }
 
-    override fun connect() {
-        stateFlow.update { it.copy(isConnecting = true, bluetoothConnectionError = null) }
-        val state = stateFlow.value
-        if (!state.isBluetoothReady || state.isConnected){
+    override fun connect(deviceAddress: String) {
+        if (!stateFlow.value.isBluetoothReady) {
+            stateFlow.update { it.copy(isConnecting = false, bluetoothConnectionError = ConnectionError.BLUETOOTH_DISABLED) }
             return
         }
-        if (bluetoothGatt != null){
-            val isReconnect = bluetoothGatt?.connect()
-            if (isReconnect == true) return
+        if (stateFlow.value.isConnected && stateFlow.value.connectedDevice?.bluetoothDevice?.address == deviceAddress) {
+            stateFlow.update{ it.copy(isConnecting = false)} // Already connected to this one
+            return
         }
-        bluetoothGatt = bluetoothDevice?.connectGatt(applicationContext, false, gattCallback, BluetoothDevice.TRANSPORT_LE)
+        if (stateFlow.value.isConnecting) return // Already trying to connect
+
+        stateFlow.update { it.copy(isConnecting = true, bluetoothConnectionError = null) }
+
+        val deviceToConnect = stateFlow.value.discoveredDevices[deviceAddress]?.bluetoothDevice
+            ?: bluetoothAdapter?.getRemoteDevice(deviceAddress) // Fallback for known devices not in cache
+
+        if (deviceToConnect == null) {
+            stateFlow.update { it.copy(isConnecting = false, bluetoothConnectionError = ConnectionError.BLUETOOTH_PRINTER_DEVICE_NOT_FOUND) }
+            return
+        }
+
+        // If the original connection is active to a DIFFERENT device, disconnect it.
+        if (bluetoothGatt != null && bluetoothGatt?.device?.address != deviceToConnect.address) {
+            bluetoothGatt?.disconnect() // gattCallback will close it
+            bluetoothGatt = null
+            characteristic = null
+        }
+
+        // Connect
+        bluetoothGatt = deviceToConnect.connectGatt(applicationContext, false, gattCallback, BluetoothDevice.TRANSPORT_LE)
+        stateFlow.update { it.copy(isConnecting = false, bluetoothConnectionError = null, connectedDevice = stateFlow.value.discoveredDevices[deviceAddress]) }
     }
 
     override fun disconnect() {
         val state = stateFlow.value
         if (!state.isBluetoothReady || !state.isConnected || bluetoothGatt == null) return
         bluetoothGatt?.disconnect()
+        stateFlow.update { it.copy(connectedDevice = null) }
     }
 
     override  fun print(data: ByteArray) {
@@ -220,9 +262,13 @@ internal class AndroidBluetoothConnection: BlueLine {
         if (stateFlow.value.isScanning){
             bluetoothLeScanner?.stopScan(scanCallback)
             stateFlow.update { it.copy(isScanning = false) }
-        }
-        if (bluetoothLeScanner == null){
+        } else {
             bluetoothLeScanner = bluetoothAdapter?.bluetoothLeScanner
+        }
+
+        if (bluetoothLeScanner == null) {
+            stateFlow.update { it.copy(bluetoothConnectionError = ConnectionError.BLUETOOTH_ADAPTER_ERROR, isScanning = false) }
+            return
         }
         stateFlow.update { it.copy(bluetoothConnectionError = null, isScanning = true) }
 
@@ -238,7 +284,7 @@ internal class AndroidBluetoothConnection: BlueLine {
         }
 
         bluetoothLeScanner?.stopScan(scanCallback)
-
+        stateFlow.update { it.copy(isScanning = false) }
     }
 
     private fun BluetoothDevice.isPrinter(): Boolean{

--- a/core/src/androidMain/kotlin/com/dilivva/blueline/core/connection/bluetooth/connection.android.kt
+++ b/core/src/androidMain/kotlin/com/dilivva/blueline/core/connection/bluetooth/connection.android.kt
@@ -23,6 +23,9 @@
 
 package com.dilivva.blueline.core.connection.bluetooth
 
+import android.bluetooth.BluetoothDevice
+
 
 @Suppress("unused")
 actual fun BlueLine(): BlueLine = AndroidBluetoothConnection()
+actual typealias PlatformBluetoothDevice = BluetoothDevice

--- a/core/src/commonMain/kotlin/com/dilivva/blueline/core/connection/bluetooth/BlueLine.kt
+++ b/core/src/commonMain/kotlin/com/dilivva/blueline/core/connection/bluetooth/BlueLine.kt
@@ -73,8 +73,7 @@ interface BlueLine {
      * This method tries to connect to the printer that was found during the last [scanForPrinters] call.
      * It's important to ensure a successful [scanForPrinters] execution before calling [connect].
      */
-    fun connect()
-
+    fun connect(deviceAddress: String)
     /**
      * Disconnects from the currently connected Bluetooth printer.
      *

--- a/core/src/commonMain/kotlin/com/dilivva/blueline/core/connection/bluetooth/Connection.kt
+++ b/core/src/commonMain/kotlin/com/dilivva/blueline/core/connection/bluetooth/Connection.kt
@@ -45,7 +45,11 @@ enum class ConnectionError {
 
     BLUETOOTH_PRINT_ERROR,
 
-    BLUETOOTH_PRINTER_DEVICE_NOT_FOUND
+    BLUETOOTH_PRINTER_DEVICE_NOT_FOUND,
+
+    BLUETOOTH_SCAN_FAILED,
+
+    BLUETOOTH_ADAPTER_ERROR
 }
 
 
@@ -56,7 +60,8 @@ enum class ConnectionError {
  * and details involved in connecting to a printer. It can be used to keep track of the
  * connection progress, communicate status to the UI, and provide context for error handling.
  *
- * @property deviceName A human-readable name representing the current device.
+ * @property connectedDevice A wrapper of the Bluetooth device that is currently connected.
+ * @property discoveredDevices A list of discovered devices during scanning process.
  * @property discoveredPrinter Indicates whether a printer has been discovered during the search process.
  * @property canPrint Indicates if the discovered printer is considered printable (might depend on additional factors like compatibility or supported features).
  * @property isConnected Indicates if a successful connection has been established with the printer.
@@ -67,7 +72,8 @@ enum class ConnectionError {
  * @property isConnecting Indicates if the system is attempting to connect to the printer
  */
 data class ConnectionState(
-    val deviceName: String = "Searching",
+    val connectedDevice: SimpleBluetoothDevice? = null,
+    val discoveredDevices: MutableMap<String, SimpleBluetoothDevice> = mutableMapOf(),
     val discoveredPrinter: Boolean = false,
     val canPrint: Boolean = false,
     val isConnected: Boolean = false,
@@ -75,5 +81,13 @@ data class ConnectionState(
     val bluetoothConnectionError: ConnectionError? = null,
     val isPrinting: Boolean = false,
     val isScanning: Boolean = false,
-    val isConnecting:Boolean = false
+    val isConnecting:Boolean = false,
 )
+
+class SimpleBluetoothDevice(
+    val name: String,
+    val address: String,
+    val bluetoothDevice: PlatformBluetoothDevice
+)
+
+expect class PlatformBluetoothDevice

--- a/core/src/iosMain/kotlin/com/dilivva/blueline/core/connection/bluetooth/ScanningManager.kt
+++ b/core/src/iosMain/kotlin/com/dilivva/blueline/core/connection/bluetooth/ScanningManager.kt
@@ -65,7 +65,6 @@ internal class ScanningManager(
         advertisementData: Map<Any?, *>,
         RSSI: NSNumber
     ) {
-        central.stopScan()
         onDevice(didDiscoverPeripheral)
     }
 

--- a/core/src/iosMain/kotlin/com/dilivva/blueline/core/connection/bluetooth/connection.ios.kt
+++ b/core/src/iosMain/kotlin/com/dilivva/blueline/core/connection/bluetooth/connection.ios.kt
@@ -22,6 +22,9 @@
 
 package com.dilivva.blueline.core.connection.bluetooth
 
+import platform.CoreBluetooth.CBPeripheral
+
 
 @Suppress("unused")
 actual fun BlueLine(): BlueLine = IosBluetoothConnection
+actual typealias PlatformBluetoothDevice = CBPeripheral


### PR DESCRIPTION
I created this PR to have an option to list down all discovered devices, and the option to connect to a specific device.

So the key changes are, in `ConnectionState`, I've added 2 new properties.
```kotlin
data class ConnectionState(
    val connectedDevice: SimpleBluetoothDevice? = null,
    val discoveredDevices: MutableMap<String, SimpleBluetoothDevice> = mutableMapOf(),
    ....
)
```
If `scanForPrinters` is called, it will not stop scanning until after 5 seconds. Whenever a device is detected during the scan, it will be added into `discoveredDevices`.

`connect(deviceAddress: String)` will now be for a specific device. This is a breaking change, but could easily be mitigated by the following:
```kotlin
    val discoveredDevices = connectionState.discoveredDevices
    val firstAddress = discoveredDevices.entries.first()
    connection.connect(firstAddress.value.address)
```

                   